### PR TITLE
Rearrange control panel and square buttons

### DIFF
--- a/color-flood-3d/src/games/color-flood/ColorFloodGame.css
+++ b/color-flood-3d/src/games/color-flood/ColorFloodGame.css
@@ -400,7 +400,7 @@
   width: 2.5rem;
   height: 2.5rem;
   border: none;
-  border-radius: 50%;
+  border-radius: 0;
   background: rgba(255, 255, 255, 0.2);
   color: white;
   font-size: 1.2rem;
@@ -496,7 +496,7 @@
   width: 100%;
   height: 3rem;
   border: 2px solid transparent;
-  border-radius: 0.75rem;
+  border-radius: 0;
   cursor: pointer;
   transition: all 0.3s ease;
   position: relative;
@@ -918,16 +918,17 @@
 
 /* Game Controls */
 .control-buttons {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.5rem;
-  justify-content: center;
+  justify-items: center;
 }
 
 .control-button {
   width: 3rem;
   height: 3rem;
   border: none;
-  border-radius: 8px;
+  border-radius: 0;
   background: rgba(255, 255, 255, 0.2);
   color: white;
   font-size: 1.6rem;
@@ -1046,7 +1047,7 @@
   width: 3rem;
   height: 3rem;
   border: 2px solid transparent;
-  border-radius: 8px;
+  border-radius: 0;
   cursor: pointer;
   transition: all 0.3s ease;
   position: relative;

--- a/color-flood-3d/src/games/color-flood/ui/UnifiedControlPanel.tsx
+++ b/color-flood-3d/src/games/color-flood/ui/UnifiedControlPanel.tsx
@@ -56,8 +56,39 @@ export const UnifiedControlPanel: React.FC<UnifiedControlPanelProps> = ({ classN
   
   return (
     <div className={`unified-control-panel ${className}`}>
-      {/* Row 1: Game Controls */}
+      {/* Row 1: Color Palette */}
       <div className="control-row row-1">
+        <div className="control-section color-section">
+          <div className="color-grid">
+            {palette.colors.map((color, index) => {
+              const colorIndex = index as ColorIndex;
+              const isHovered = hoveredColor === colorIndex;
+
+              return (
+                <button
+                  key={colorIndex}
+                  className={`color-button ${isHovered ? 'hovered' : ''} ${isDisabled ? 'disabled' : ''}`}
+                  style={{
+                    backgroundColor: color,
+                    borderColor: color,
+                    transform: isHovered ? 'scale(1.05)' : 'scale(1)',
+                    boxShadow: isHovered
+                      ? `0 0 0 2px ${color}60, 0 4px 8px ${color}40`
+                      : '0 2px 4px rgba(0,0,0,0.15)',
+                  }}
+                  onClick={() => handleColorClick(colorIndex)}
+                  onMouseEnter={() => setHoveredColor(colorIndex)}
+                  onMouseLeave={() => setHoveredColor(null)}
+                  disabled={isDisabled}
+                  title={`Select color ${colorIndex + 1} (Press ${colorIndex + 1})`}
+                >
+                  <span className="color-number">{colorIndex + 1}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         <div className="control-section game-controls">
           <div className="control-buttons">
             <button
@@ -94,38 +125,6 @@ export const UnifiedControlPanel: React.FC<UnifiedControlPanelProps> = ({ classN
             >
               💡
             </button>
-          </div>
-        </div>
-        
-        {/* Color Palette */}
-        <div className="control-section color-section">
-          <div className="color-grid">
-            {palette.colors.map((color, index) => {
-              const colorIndex = index as ColorIndex;
-              const isHovered = hoveredColor === colorIndex;
-              
-              return (
-                <button
-                  key={colorIndex}
-                  className={`color-button ${isHovered ? 'hovered' : ''} ${isDisabled ? 'disabled' : ''}`}
-                  style={{
-                    backgroundColor: color,
-                    borderColor: color,
-                    transform: isHovered ? 'scale(1.05)' : 'scale(1)',
-                    boxShadow: isHovered
-                      ? `0 0 0 2px ${color}60, 0 4px 8px ${color}40`
-                      : '0 2px 4px rgba(0,0,0,0.15)',
-                  }}
-                  onClick={() => handleColorClick(colorIndex)}
-                  onMouseEnter={() => setHoveredColor(colorIndex)}
-                  onMouseLeave={() => setHoveredColor(null)}
-                  disabled={isDisabled}
-                  title={`Select color ${colorIndex + 1} (Press ${colorIndex + 1})`}
-                >
-                  <span className="color-number">{colorIndex + 1}</span>
-                </button>
-              );
-            })}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- swap palette and button order so color buttons appear first
- display control buttons in a 2x2 grid
- remove rounded corners from control and color buttons

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e66e91448323a43f8b24e8c06077