### PR TITLE
Adjust cube appearance

### DIFF
--- a/color-flood-3d/src/engine/CubeMesh.tsx
+++ b/color-flood-3d/src/engine/CubeMesh.tsx
@@ -185,8 +185,8 @@ export const CubeMesh: React.FC<CubeMeshProps> = ({
       >
         <boxGeometry args={[0.9, 0.9, 0.9]} />
         <meshStandardMaterial
-          roughness={0.3}
-          metalness={0.1}
+          roughness={0.8}
+          metalness={0}
           transparent={false}
         />
       </instancedMesh>

--- a/color-flood-3d/src/games/color-flood/ColorFloodGame.tsx
+++ b/color-flood-3d/src/games/color-flood/ColorFloodGame.tsx
@@ -50,7 +50,7 @@ const AnimatedGroup: React.FC<AnimatedGroupProps> = ({ rotation, children }) => 
     }
   });
   
-  return <group ref={groupRef}>{children}</group>;
+  return <group ref={groupRef} scale={[1.2, 1.2, 1.2]}>{children}</group>;
 };
 
 const CubeScene: React.FC<CubeSceneProps> = ({ onCellClick }) => {

--- a/color-flood-3d/src/games/color-flood/logic/types.ts
+++ b/color-flood-3d/src/games/color-flood/logic/types.ts
@@ -38,7 +38,7 @@ export const DEFAULT_PALETTES: ColorPalette[] = [
       '#2ECC71', // Bright Green
       '#F39C12', // Bright Orange
       '#9B59B6', // Bright Purple
-      '#F1C40F', // Bright Yellow
+      '#FFFFFF', // White for better contrast
     ],
   },
   {
@@ -49,7 +49,7 @@ export const DEFAULT_PALETTES: ColorPalette[] = [
       '#45B7D1', // Sky Blue
       '#96CEB4', // Mint Green
       '#FFEAA7', // Peach
-      '#DDA0DD', // Plum
+      '#FFFFFF', // White for better contrast
     ],
   },
   {
@@ -60,7 +60,7 @@ export const DEFAULT_PALETTES: ColorPalette[] = [
       '#FFC107', // Amber
       '#8BC34A', // Light Green
       '#00BCD4', // Cyan
-      '#673AB7', // Deep Purple
+      '#FFFFFF', // White for better contrast
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- reduce shine on cube by increasing roughness and removing metalness
- enlarge cube by scaling parent group
- use white as the last palette color for better contrast

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869eadeeb58832396577f034cc8abb0